### PR TITLE
Fix mobile todos week view to show full 7-day calendar

### DIFF
--- a/components/Todos/WeekView.js
+++ b/components/Todos/WeekView.js
@@ -54,36 +54,38 @@ export default function WeekView({ todos, onToggle }) {
         <span className={styles.weekLabel}>{formatWeekRange(weekStart)}</span>
       </div>
 
-      <div className={styles.weekGrid}>
-        {days.map((day) => {
-          const isToday = day.dateStr === todayStr
-          const dayTodos = todos.filter((t) => t.dueDate === day.dateStr)
+      <div className={styles.weekGridWrapper}>
+        <div className={styles.weekGrid}>
+          {days.map((day) => {
+            const isToday = day.dateStr === todayStr
+            const dayTodos = todos.filter((t) => t.dueDate === day.dateStr)
 
-          return (
-            <div key={day.dateStr} className={styles.weekDay}>
-              <div className={`${styles.weekDayHeader} ${isToday ? styles.weekDayToday : ""}`}>
-                {day.label}
-                <span className={styles.weekDayDate}>{day.date.getDate()}</span>
-              </div>
-              <div className={styles.weekDayItems}>
-                {dayTodos.map((todo) => (
-                  <div
-                    key={todo.id}
-                    className={styles.weekTodoItem}
-                    onClick={() => onToggle(todo.id, !todo.completed)}
-                  >
-                    <div className={`${styles.weekTodoCheckbox} ${todo.completed ? styles.weekTodoCheckboxDone : ""}`}>
-                      {todo.completed && "✓"}
+            return (
+              <div key={day.dateStr} className={styles.weekDay}>
+                <div className={`${styles.weekDayHeader} ${isToday ? styles.weekDayToday : ""}`}>
+                  {day.label}
+                  <span className={styles.weekDayDate}>{day.date.getDate()}</span>
+                </div>
+                <div className={styles.weekDayItems}>
+                  {dayTodos.map((todo) => (
+                    <div
+                      key={todo.id}
+                      className={styles.weekTodoItem}
+                      onClick={() => onToggle(todo.id, !todo.completed)}
+                    >
+                      <div className={`${styles.weekTodoCheckbox} ${todo.completed ? styles.weekTodoCheckboxDone : ""}`}>
+                        {todo.completed && "✓"}
+                      </div>
+                      <span className={`${styles.weekTodoText} ${todo.completed ? styles.weekTodoTextDone : ""}`}>
+                        {todo.text}
+                      </span>
                     </div>
-                    <span className={`${styles.weekTodoText} ${todo.completed ? styles.weekTodoTextDone : ""}`}>
-                      {todo.text}
-                    </span>
-                  </div>
-                ))}
+                  ))}
+                </div>
               </div>
-            </div>
-          )
-        })}
+            )
+          })}
+        </div>
       </div>
 
       {unscheduled.length > 0 && (

--- a/styles/Todos.module.css
+++ b/styles/Todos.module.css
@@ -373,6 +373,11 @@
   text-align: center;
 }
 
+.weekGridWrapper {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
 .weekGrid {
   display: grid;
   grid-template-columns: repeat(7, 1fr);
@@ -556,26 +561,41 @@
     opacity: 1;
   }
 
-  /* Week view: stack days vertically */
+  /* Week view: keep 7-column layout, allow horizontal scroll */
   .weekGrid {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(7, 1fr);
+    min-width: 500px;
   }
 
   .weekDay {
-    min-height: auto;
+    min-height: 120px;
   }
 
   .weekDayHeader {
-    text-align: left;
-    padding: 0.4rem 0.6rem;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
+    text-align: center;
+    padding: 0.3rem 0.15rem 0.2rem;
+    font-size: 0.6rem;
   }
 
   .weekDayDate {
-    display: inline;
-    margin-top: 0;
+    font-size: 0.75rem;
+  }
+
+  .weekDayItems {
+    padding: 0.15rem;
+  }
+
+  .weekTodoItem {
+    font-size: 0.65rem;
+    padding: 0.15rem 0.15rem;
+    gap: 0.15rem;
+  }
+
+  .weekTodoCheckbox {
+    width: 11px;
+    height: 11px;
+    border-radius: 2px;
+    font-size: 0.45rem;
   }
 
   .weekNav {


### PR DESCRIPTION
Previously, the week grid stacked days vertically on mobile (single column),
hiding the weekly calendar layout. Now keeps all 7 columns visible with a
horizontally scrollable wrapper and compact styling for mobile screens.

https://claude.ai/code/session_011DM5uwFzMokezYJKR3N3jQ